### PR TITLE
Upgraded to use CMake and applied existing patches.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,92 @@
+cmake_minimum_required(VERSION 3.4.3)
+
+project(B64 VERSION 1.2.2 LANGUAGES C CXX)
+
+option(B64_SHARED      "Enable shared library"            OFF)
+option(B64_PIC         "Enable Position independent code" OFF)
+
+if (NOT add_compile_definitions)
+    macro(add_compile_definitions)
+        add_definitions(${ARGV})
+    endmacro()
+endif()
+
+if (NOT add_link_options)
+    macro(add_link_options)
+        set(CMAKE_C_LINK_FLAGS "${CMAKE_C_LINK_FLAGS} ${ARGV}")
+        set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} ${ARGV}")
+    endmacro()
+endif()
+
+
+if (B64_PIC)
+   add_compile_options(-fpic)
+endif()
+
+if (B64_SHARED)
+   set(B64_LIB_TYPE SHARED)
+else()
+    set(B64_LIB_TYPE STATIC)
+endif()
+
+add_compile_options(
+    -Wall
+    -Werror
+    -pedantic
+    -ffunction-sections
+    -fdata-sections)
+add_link_options(-Wl,--gc-sections)
+if (${CMAKE_BUILD_TYPE} STREQUAL "Debug")
+   add_compile_options(-fstack-protector-all -O0 -Wa,-g)
+   add_definitions(-DBUILD_DEBUG)
+elseif (${CMAKE_BUILD_TYPE} STREQUAL "Profile")
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fstrict-enums>)
+    add_compile_options(-fmerge-all-constants -O3 -pg -fno-inline)
+    add_compile_definitions(-DBUILD_PROFILE -DNDEBUG)
+elseif (${CMAKE_BUILD_TYPE} STREQUAL "Release")
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fstrict-enums>)
+    add_compile_options(
+        -fmerge-all-constants
+        -fomit-frame-pointer
+        -O3
+        -fno-stack-protector)
+    add_compile_definitions(-DBUILD_RELEASE -DNDEBUG)
+endif()
+
+# libb64
+add_library(
+    b64
+    ${B64_LIB_TYPE}
+    src/cencode.c
+    src/cdecode.c)
+target_include_directories(
+    b64
+    PUBLIC
+    ./include)
+
+# base64
+add_executable(
+    base64
+    base64/base64.cc)
+target_link_libraries(base64 b64)
+
+# examples
+add_executable(
+    c-example1
+    examples/c-example1.c)
+target_link_libraries(c-example1 b64)
+add_custom_target(test-c-example1
+    COMMAND echo "*** Test c-example1 ***"
+    COMMAND ${CMAKE_BINARY_DIR}/c-example1
+    DEPENDS c-example1)
+
+add_executable(
+    c-example2
+    examples/c-example2.c)
+target_link_libraries(c-example2 b64)
+add_custom_target(test-c-example2
+    COMMAND echo "*** Test c-example2 ***"
+    COMMAND ${CMAKE_BINARY_DIR}/c-example2 loremgibson.txt encoded.txt decoded.txt
+    COMMAND diff -q loremgibson.txt decoded.txt
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/examples
+    DEPENDS c-example2)

--- a/base64/Makefile
+++ b/base64/Makefile
@@ -13,7 +13,7 @@ CFLAGS += -O3
 # a larger size should be faster, but takes more runtime memory
 #BUFFERSIZE = 4096
 #BUFFERSIZE = 65536
-BUFFERSIZE = 16777216
+#BUFFERSIZE = 16777216
 
 SOURCES = base64.cc
 
@@ -22,7 +22,7 @@ TARGETS = $(BINARIES)
 LINK.o = g++
 
 CFLAGS += -Werror -pedantic
-CFLAGS += -DBUFFERSIZE=$(BUFFERSIZE)
+#CFLAGS += -DBUFFERSIZE=$(BUFFERSIZE)
 CFLAGS += -I../include
 
 CXXFLAGS += $(CFLAGS)

--- a/include/b64/decode.h
+++ b/include/b64/decode.h
@@ -19,6 +19,8 @@ namespace base64
 
 	struct decoder
 	{
+        enum { BUFFERSIZE = 65536 };
+
 		base64_decodestate _state;
 		int _buffersize;
 

--- a/include/b64/encode.h
+++ b/include/b64/encode.h
@@ -19,21 +19,25 @@ namespace base64
 
 	struct encoder
 	{
+		enum { BUFFERSIZE = 65536 };
+
 		base64_encodestate _state;
 		int _buffersize;
 
 		encoder(int buffersize_in = BUFFERSIZE)
 		: _buffersize(buffersize_in)
-		{}
+		{
+			base64_init_encodestate(&_state);
+		}
 
 		int encode(char value_in)
 		{
 			return base64_encode_value(value_in);
 		}
 
-		int encode(const char* code_in, const int length_in, char* plaintext_out)
+		int encode(const char* plaintext_in, int length_in, char* code_out)
 		{
-			return base64_encode_block(code_in, length_in, plaintext_out, &_state);
+			return base64_encode_block(plaintext_in, length_in, code_out, &_state);
 		}
 
 		int encode_end(char* plaintext_out)
@@ -43,8 +47,6 @@ namespace base64
 
 		void encode(std::istream& istream_in, std::ostream& ostream_in)
 		{
-			base64_init_encodestate(&_state);
-			//
 			const int N = _buffersize;
 			char* plaintext = new char[N];
 			char* code = new char[2*N];

--- a/src/cdecode.c
+++ b/src/cdecode.c
@@ -9,10 +9,11 @@ For details, see http://sourceforge.net/projects/libb64
 
 int base64_decode_value(char value_in)
 {
-	static const char decoding[] = {62,-1,-1,-1,63,52,53,54,55,56,57,58,59,60,61,-1,-1,-1,-2,-1,-1,-1,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,-1,-1,-1,-1,-1,-1,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51};
+	static const signed char decoding[] = {62,-1,-1,-1,63,52,53,54,55,56,57,58,59,60,61,-1,-1,-1,-2,-1,-1,-1,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,-1,-1,-1,-1,-1,-1,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51};
 	static const char decoding_size = sizeof(decoding);
+	if (value_in < 43) return -1;
 	value_in -= 43;
-	if (value_in < 0 || value_in >= decoding_size) return -1;
+	if (value_in >= decoding_size) return -1;
 	return decoding[(int)value_in];
 }
 
@@ -26,7 +27,7 @@ int base64_decode_block(const char* code_in, const int length_in, char* plaintex
 {
 	const char* codechar = code_in;
 	char* plainchar = plaintext_out;
-	char fragment;
+	int fragment;
 	
 	*plainchar = state_in->plainchar;
 	
@@ -42,7 +43,7 @@ int base64_decode_block(const char* code_in, const int length_in, char* plaintex
 					state_in->plainchar = *plainchar;
 					return plainchar - plaintext_out;
 				}
-				fragment = (char)base64_decode_value(*codechar++);
+				fragment = base64_decode_value(*codechar++);
 			} while (fragment < 0);
 			*plainchar    = (fragment & 0x03f) << 2;
 	case step_b:
@@ -53,7 +54,7 @@ int base64_decode_block(const char* code_in, const int length_in, char* plaintex
 					state_in->plainchar = *plainchar;
 					return plainchar - plaintext_out;
 				}
-				fragment = (char)base64_decode_value(*codechar++);
+				fragment = base64_decode_value(*codechar++);
 			} while (fragment < 0);
 			*plainchar++ |= (fragment & 0x030) >> 4;
 			*plainchar    = (fragment & 0x00f) << 4;
@@ -65,7 +66,7 @@ int base64_decode_block(const char* code_in, const int length_in, char* plaintex
 					state_in->plainchar = *plainchar;
 					return plainchar - plaintext_out;
 				}
-				fragment = (char)base64_decode_value(*codechar++);
+				fragment = base64_decode_value(*codechar++);
 			} while (fragment < 0);
 			*plainchar++ |= (fragment & 0x03c) >> 2;
 			*plainchar    = (fragment & 0x003) << 6;
@@ -77,7 +78,7 @@ int base64_decode_block(const char* code_in, const int length_in, char* plaintex
 					state_in->plainchar = *plainchar;
 					return plainchar - plaintext_out;
 				}
-				fragment = (char)base64_decode_value(*codechar++);
+				fragment = base64_decode_value(*codechar++);
 			} while (fragment < 0);
 			*plainchar++   |= (fragment & 0x03f);
 		}

--- a/src/cencode.c
+++ b/src/cencode.c
@@ -7,7 +7,7 @@ For details, see http://sourceforge.net/projects/libb64
 
 #include <b64/cencode.h>
 
-const int CHARS_PER_LINE = 72;
+static const int CHARS_PER_LINE = 72;
 
 void base64_init_encodestate(base64_encodestate* state_in)
 {


### PR DESCRIPTION
Upgraded to use CMake and applied the following existing patches on source-forge, integer-overflows-3.diff, static-chars-per-line.diff & cpp-encoding.patch.